### PR TITLE
Feat/scan source

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ services:
       # this variable, unless you have multiple scanners and you want to use a
       # specific one.
       # SCANNER_OVERRIDE: your-scanner
+      # Scanner source to use. Must be one of "platen", "adf".
+      # Defaults to "platen".
+      # SCANNER_SOURCE: adf
     volumes:
       - "/tmp:/tmp"
       - "/final:/final"

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ services:
       # this variable, unless you have multiple scanners and you want to use a
       # specific one.
       # SCANNER_OVERRIDE: your-scanner
-      # Scanner source to use. Must be one of "platen", "adf".
-      # Defaults to "platen".
+      # Scanner source to use. Must be one of "flatbed", "adf".
+      # Defaults to "flatbed".
       # SCANNER_SOURCE: adf
     volumes:
       - "/tmp:/tmp"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/kn100/telescan
 
+replace github.com/kn100/telescan => ./
+
 go 1.20
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,4 @@
-module github.com/kn100/telescan
-
-replace github.com/kn100/telescan => ./
+module github.com/stnokott/telescan
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kn100/telescan/scanner"
-	"github.com/kn100/telescan/scansession"
-	"github.com/kn100/telescan/tg"
+	"github.com/stnokott/telescan/scanner"
+	"github.com/stnokott/telescan/scansession"
+	"github.com/stnokott/telescan/tg"
 	"go.uber.org/zap"
 )
 

--- a/main.go
+++ b/main.go
@@ -56,9 +56,12 @@ func env(key, def string) string {
 }
 
 func mustGetScannerSource() string {
-	scannerSource := strings.ToLower(env("SCANNER_SOURCE", "platen"))
-	if scannerSource != "platen" && scannerSource != "adf" {
-		panic(`environment variable SCANNER_SOURCE needs to be one of "platen", "adf"`)
+	scannerSource := strings.ToLower(env("SCANNER_SOURCE", "flatbed"))
+	if scannerSource == "flatbed" {
+		return "Platen"
 	}
-	return scannerSource
+	if scannerSource == "adf" {
+		return "Feeder"
+	}
+	panic(`environment variable SCANNER_SOURCE needs to be one of "flatbed", "adf"`)
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	sugar := logger.Sugar()
 
-	scannerManager := scanner.NewManager(sugar, env("SCANNER_OVERRIDE", ""))
+	scannerManager := scanner.NewManager(sugar, env("SCANNER_OVERRIDE", ""), mustGetScannerSource())
 	scannerManager.Start()
 
 	scanSessionManager := scansession.NewManager(
@@ -53,4 +53,12 @@ func env(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func mustGetScannerSource() string {
+	scannerSource := strings.ToLower(env("SCANNER_SOURCE", "platen"))
+	if scannerSource != "platen" && scannerSource != "adf" {
+		panic(`environment variable SCANNER_SOURCE needs to be one of "platen", "adf"`)
+	}
+	return scannerSource
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -2,8 +2,10 @@ package scanner
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/brutella/dnssd"
@@ -45,6 +47,10 @@ func (s *Scanner) Scan() ([]byte, error) {
 	s.UpdateState(ScannerStateBusy)
 
 	cl := airscan.NewClientForService(s.DNSSDBrowseEntry)
+
+	transport := cl.HTTPClient.(*http.Client).Transport.(*http.Transport)
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 	status, err := cl.ScannerStatus()
 	s.logger.Infof("ScannerStatus(): status=%v, err=%v", status, err)
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -54,9 +54,7 @@ func (s *Scanner) Scan() ([]byte, error) {
 	status, err := cl.ScannerStatus()
 	s.logger.Infof("ScannerStatus(): status=%v, err=%v", status, err)
 
-	settings := s.scanSettings()
-	s.logger.Infof("settings: %v", settings)
-	scan, err := cl.Scan(settings)
+	scan, err := cl.Scan(s.scanSettings())
 	if err != nil {
 		s.UpdateState(ScannerStateIdle)
 		return nil, err

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -46,9 +46,6 @@ func (s *Scanner) Scan() ([]byte, error) {
 
 	cl := airscan.NewClientForService(s.DNSSDBrowseEntry)
 
-	status, err := cl.ScannerStatus()
-	s.logger.Infof("ScannerStatus(): status=%v, err=%v", status, err)
-
 	scan, err := cl.Scan(s.scanSettings())
 	if err != nil {
 		s.UpdateState(ScannerStateIdle)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -24,13 +24,15 @@ const (
 type Scanner struct {
 	DNSSDBrowseEntry *dnssd.BrowseEntry
 	State            ScannerState
+	source           string
 	logger           *zap.SugaredLogger
 }
 
-func Init(srv *dnssd.BrowseEntry, logger *zap.SugaredLogger) *Scanner {
+func Init(srv *dnssd.BrowseEntry, logger *zap.SugaredLogger, source string) *Scanner {
 	return &Scanner{
 		DNSSDBrowseEntry: srv,
 		State:            ScannerStateIdle,
+		source:           source,
 		logger:           logger,
 	}
 }
@@ -44,7 +46,7 @@ func (s *Scanner) Scan() ([]byte, error) {
 
 	cl := airscan.NewClientForService(s.DNSSDBrowseEntry)
 
-	scan, err := cl.Scan(scanSettings())
+	scan, err := cl.Scan(s.scanSettings())
 	if err != nil {
 		s.UpdateState(ScannerStateIdle)
 		return nil, err
@@ -85,10 +87,10 @@ func (s *Scanner) DeviceName() string {
 	return strings.ReplaceAll(s.DNSSDBrowseEntry.Name, "\\", "")
 }
 
-func scanSettings() *airscan.ScanSettings {
+func (s *Scanner) scanSettings() *airscan.ScanSettings {
 	settings := preset.GrayscaleA4ADF()
 	settings.ColorMode = "RGB24"
-	settings.InputSource = "Platen"
+	settings.InputSource = s.source
 	settings.DocumentFormat = "image/jpeg"
 	return settings
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -45,6 +45,8 @@ func (s *Scanner) Scan() ([]byte, error) {
 	s.UpdateState(ScannerStateBusy)
 
 	cl := airscan.NewClientForService(s.DNSSDBrowseEntry)
+	status, err := cl.ScannerStatus()
+	s.logger.Infof("ScannerStatus(): status=%v, err=%v", status, err)
 
 	settings := s.scanSettings()
 	s.logger.Infof("settings: %v", settings)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -46,7 +46,9 @@ func (s *Scanner) Scan() ([]byte, error) {
 
 	cl := airscan.NewClientForService(s.DNSSDBrowseEntry)
 
-	scan, err := cl.Scan(s.scanSettings())
+	settings := s.scanSettings()
+	s.logger.Infof("settings: %v", settings)
+	scan, err := cl.Scan(settings)
 	if err != nil {
 		s.UpdateState(ScannerStateIdle)
 		return nil, err

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -2,10 +2,8 @@ package scanner
 
 import (
 	"bytes"
-	"crypto/tls"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/brutella/dnssd"
@@ -47,9 +45,6 @@ func (s *Scanner) Scan() ([]byte, error) {
 	s.UpdateState(ScannerStateBusy)
 
 	cl := airscan.NewClientForService(s.DNSSDBrowseEntry)
-
-	transport := cl.HTTPClient.(*http.Client).Transport.(*http.Transport)
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	status, err := cl.ScannerStatus()
 	s.logger.Infof("ScannerStatus(): status=%v, err=%v", status, err)

--- a/scanner/scannermanager.go
+++ b/scanner/scannermanager.go
@@ -13,13 +13,15 @@ type Manager struct {
 	logger          *zap.SugaredLogger
 	scanners        []*Scanner
 	scannerOverride string
+	scannerSource   string
 	isStarted       bool
 }
 
-func NewManager(logger *zap.SugaredLogger, scannerOverride string) *Manager {
+func NewManager(logger *zap.SugaredLogger, scannerOverride string, scannerSource string) *Manager {
 	return &Manager{
 		logger:          logger,
 		scannerOverride: scannerOverride,
+		scannerSource:   scannerSource,
 	}
 }
 
@@ -39,7 +41,7 @@ func (s *Manager) Start() {
 			}
 		}
 		s.logger.Infof("Found new scanner %s, adding to list of scanners", srv.Host)
-		s.scanners = append(s.scanners, Init(&srv, s.logger))
+		s.scanners = append(s.scanners, Init(&srv, s.logger, s.scannerSource))
 	}
 
 	rmvFn := func(srv dnssd.BrowseEntry) {

--- a/tg/tg.go
+++ b/tg/tg.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
-	"github.com/kn100/telescan/scanner"
-	"github.com/kn100/telescan/scansession"
+	"github.com/stnokott/telescan/scanner"
+	"github.com/stnokott/telescan/scansession"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 )


### PR DESCRIPTION
Adds environment variable `SCANNER_SOURCE`.

Currently a draft until the following points are cleared:

- [ ] Is "flatbed" as equivalent to "platen" ok? For me at least, the former is more common, this way we translate between that term and what the scanner accepts
- [ ] change module name back to `github.com/kn100/telescan` (I had to rename it to install it via `go install` from my fork)

Once the first point is cleared by @kn100 , I will resolve the second point and mark the PR as ready.